### PR TITLE
Ignore __pycache__ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#Build results
+__pycache__


### PR DESCRIPTION
These are generated by Python 3.6+ when you run Cura from source.