### PR TITLE
Fix UTF-8 encoding

### DIFF
--- a/src/GodMode/GodMode.py
+++ b/src/GodMode/GodMode.py
@@ -56,7 +56,7 @@ def viewAllStacks():
 
 def openHtmlPage(page_name, html_contents):
     target = os.path.join(tempfile.gettempdir(), page_name)
-    with open(target, "w", encoding="utf8") as fhandle:
+    with open(target, "w", encoding="utf-8") as fhandle:
         fhandle.write(html_contents)
     QDesktopServices.openUrl(QUrl.fromLocalFile(target))
 


### PR DESCRIPTION
For CPython 3.4 utf8 is not correct. It needs to be utf-8 or UTF-8. It's not case-sensitive, but it is dash-sensitive.