### PR TITLE
Add LIB_SUFFIX to installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,10 @@ cmake_minimum_required(VERSION 3.0.0)
 
 install(FILES
     README.md
-    DESTINATION lib/cura/plugins/GodMode
+    DESTINATION lib${LIB_SUFFIX}/cura/plugins/GodMode
 )
 
 install(DIRECTORY src/GodMode
-        DESTINATION lib/cura/plugins
-        PATTERN)
+    DESTINATION lib${LIB_SUFFIX}/cura/plugins
+    PATTERN
+)


### PR DESCRIPTION
This makes it work properly on Linux systems that save their libraries in something called lib64 or something.