### PR TITLE
Update API version number

### DIFF
--- a/src/GodMode/plugin.json
+++ b/src/GodMode/plugin.json
@@ -3,5 +3,5 @@
     "author": "Ultimaker",
     "version": "1.0",
     "description": "Dump the contents of all settings to a HTML file.",
-    "api": 4
+    "api": 5
 }


### PR DESCRIPTION
I've tested this with our latest master. It still works even with the new API 5.

Your current master won't run in the latest Cura version. After merging this it will load again in the new version, but no longer in Cura 3.4.