### PR TITLE
Update to SDK version 6.0

### DIFF
--- a/src/GodMode/plugin.json
+++ b/src/GodMode/plugin.json
@@ -3,5 +3,5 @@
     "author": "Ultimaker",
     "version": "1.0",
     "description": "Dump the contents of all settings to a HTML file.",
-    "api": 5
+    "api": "6.0"
 }


### PR DESCRIPTION
This plug-in still works fine in Cura 4.0, but the view mode looks a bit weird since it has no extra button in the middle of the top bar. So the settings menu shifts towards the middle of the screen and then obscures the view a bit. It's slightly annoying but workable if you're debugging (because you probably don't need access to the settings if you're debugging scene-related stuff then).